### PR TITLE
csv_source.rb: correct call to CSV.open for Ruby 3.0

### DIFF
--- a/lib/csv-diff/csv_source.rb
+++ b/lib/csv-diff/csv_source.rb
@@ -57,7 +57,7 @@ class CSVDiff
                 @path = source
                 # When you call CSV.open, it's best to pass in a block so that after it's yielded,
                 # the underlying file handle is closed. Otherwise, you risk leaking the handle.
-                @data = CSV.open(@path, mode_string, csv_options) do |csv|
+                @data = CSV.open(@path, mode_string, **csv_options) do |csv|
                      csv.readlines
                 end
             elsif source.is_a?(Enumerable) && source.size == 0 || (source.size > 0 && source.first.is_a?(Enumerable))


### PR DESCRIPTION
Per https://stackoverflow.com/questions/71219856/ruby-csv-open-wrong-number-of-arguments-in-ruby-3-0 , the hash `csv_options` need to be spread explicitly before calling `CSV.open`.

Fixes issue at: https://github.com/agardiner/csv-diff-report/issues/16 .